### PR TITLE
Fix: Add extra padding to last column in DRE table

### DIFF
--- a/app/(protected)/dre/components/DRETableClient.tsx
+++ b/app/(protected)/dre/components/DRETableClient.tsx
@@ -106,8 +106,8 @@ export function DRETableClient({
     }).format(value);
   };
 
-  const getCellClass = (lineType: string, isBold: boolean, rowId?: string) => {
-    let classes = 'px-3 text-right border-b border-gray-200 text-xs';
+  const getCellClass = (lineType: string, isBold: boolean, rowId?: string, isLastColumn: boolean = false) => {
+    let classes = `${isLastColumn ? 'pl-3 pr-6' : 'px-3'} text-right border-b border-gray-200 text-xs`;
 
     if (lineType === 'SEPARATOR') {
       return 'px-3 py-2 border-b border-gray-300';
@@ -426,15 +426,17 @@ export function DRETableClient({
                 key={headerGroup.id}
                 className="bg-gray-50 border-b border-gray-200"
               >
-                {headerGroup.headers.map((header, index) => (
-                  <th
-                    key={header.id}
-                    className={`px-3 py-3 font-medium text-gray-900 ${
-                      index === 0
-                        ? 'text-left sticky left-0 bg-gray-50 min-w-[300px]'
-                        : 'text-center min-w-[120px]'
-                    }`}
-                  >
+                {headerGroup.headers.map((header, index) => {
+                  const isLastColumn = index === headerGroup.headers.length - 1;
+                  return (
+                    <th
+                      key={header.id}
+                      className={`${isLastColumn && index !== 0 ? 'pl-3 pr-6' : 'px-3'} py-3 font-medium text-gray-900 ${
+                        index === 0
+                          ? 'text-left sticky left-0 bg-gray-50 min-w-[300px]'
+                          : 'text-center min-w-[120px]'
+                      }`}
+                    >
                     {header.isPlaceholder
                       ? null
                       : flexRender(
@@ -442,7 +444,8 @@ export function DRETableClient({
                           header.getContext()
                         )}
                   </th>
-                ))}
+                  );
+                })}
               </tr>
             ))}
           </thead>
@@ -452,6 +455,7 @@ export function DRETableClient({
                 {row.getVisibleCells().map((cell, index) => {
                   const rowData = row.original;
                   const isNameCell = index === 0;
+                  const isLastColumn = index === row.getVisibleCells().length - 1;
 
                   return (
                     <td
@@ -470,7 +474,8 @@ export function DRETableClient({
                           : `${getCellClass(
                               rowData.lineType,
                               rowData.isBold,
-                              rowData.id
+                              rowData.id,
+                              isLastColumn
                             )}`
                       }`}
                     >


### PR DESCRIPTION
## Summary
- Added extra right padding to the last column of the DRE table
- Text was too close to the table border, affecting readability
- Applied consistent padding to both headers and data cells

## Test plan
- [ ] Navigate to the DRE page
- [ ] Select multiple months to display data
- [ ] Verify that the last column has adequate spacing from the right edge
- [ ] Check that the padding is consistent in both headers and data rows
- [ ] Test with different screen sizes to ensure proper display

🤖 Generated with [Claude Code](https://claude.ai/code)