### PR TITLE
feat(auth): gestão de usuários com e-mail e senha

### DIFF
--- a/app/(protected)/admin/users/actions.ts
+++ b/app/(protected)/admin/users/actions.ts
@@ -1,0 +1,207 @@
+"use server";
+
+import { headers } from "next/headers";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { auth } from "@/lib/core/auth/auth";
+import { getServerSession } from "@/lib/core/auth/auth-utils";
+import { requireAdmin } from "@/lib/core/auth/permission-helpers";
+import { prisma } from "@/lib/core/database/client";
+import {
+  createUserSchema,
+  firstZodError,
+  mapAuthError,
+  setPasswordSchema,
+  setRoleSchema,
+  userIdSchema,
+} from "@/lib/core/auth/user-management";
+
+export type ActionResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export type ManagedUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  role: string | null;
+  banned: boolean;
+  banReason: string | null;
+  createdAt: string;
+  emailVerified: boolean;
+  providers: string[];
+};
+
+function fail(error: unknown, fallback: string): ActionResult {
+  if (error instanceof z.ZodError) {
+    return { success: false, error: firstZodError(error) };
+  }
+  if (error instanceof Error && (error.message === "Unauthorized" || error.message === "Forbidden")) {
+    return { success: false, error: "Sem permissão para gerenciar usuários." };
+  }
+  return { success: false, error: mapAuthError(error, fallback) };
+}
+
+async function actorUserId(): Promise<string | null> {
+  const session = await getServerSession();
+  return session?.user?.id ?? null;
+}
+
+export async function listManagedUsers(): Promise<ManagedUser[]> {
+  await requireAdmin();
+
+  const users = await prisma.user.findMany({
+    orderBy: { email: "asc" },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      role: true,
+      banned: true,
+      banReason: true,
+      createdAt: true,
+      emailVerified: true,
+      accounts: {
+        select: { providerId: true },
+      },
+    },
+  });
+
+  return users.map((user) => ({
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    role: user.role,
+    banned: Boolean(user.banned),
+    banReason: user.banReason,
+    createdAt: user.createdAt.toISOString(),
+    emailVerified: user.emailVerified,
+    providers: user.accounts.map((account) => account.providerId),
+  }));
+}
+
+export async function createUserAction(input: unknown): Promise<ActionResult> {
+  try {
+    await requireAdmin();
+    const data = createUserSchema.parse(input);
+
+    await auth.api.createUser({
+      body: {
+        email: data.email,
+        password: data.password,
+        name: data.name,
+        role: data.role,
+        data: { emailVerified: true },
+      },
+      headers: await headers(),
+    });
+
+    revalidatePath("/admin/users");
+    return { success: true };
+  } catch (error) {
+    return fail(error, "Erro ao criar usuário");
+  }
+}
+
+export async function updateUserRoleAction(input: unknown): Promise<ActionResult> {
+  try {
+    await requireAdmin();
+    const data = setRoleSchema.parse(input);
+    const currentUserId = await actorUserId();
+
+    if (currentUserId && data.userId === currentUserId) {
+      return { success: false, error: "Você não pode alterar o próprio papel." };
+    }
+
+    await auth.api.setRole({
+      body: { userId: data.userId, role: data.role },
+      headers: await headers(),
+    });
+
+    revalidatePath("/admin/users");
+    return { success: true };
+  } catch (error) {
+    return fail(error, "Erro ao atualizar papel");
+  }
+}
+
+export async function setUserPasswordAction(input: unknown): Promise<ActionResult> {
+  try {
+    await requireAdmin();
+    const data = setPasswordSchema.parse(input);
+
+    await auth.api.setUserPassword({
+      body: { userId: data.userId, newPassword: data.password },
+      headers: await headers(),
+    });
+
+    revalidatePath("/admin/users");
+    return { success: true };
+  } catch (error) {
+    return fail(error, "Erro ao definir senha");
+  }
+}
+
+export async function banUserAction(input: unknown): Promise<ActionResult> {
+  try {
+    await requireAdmin();
+    const data = userIdSchema.parse(input);
+    const currentUserId = await actorUserId();
+
+    if (currentUserId && data.userId === currentUserId) {
+      return { success: false, error: "Você não pode banir a si mesmo." };
+    }
+
+    await auth.api.banUser({
+      body: {
+        userId: data.userId,
+        banReason: "Banido por um administrador",
+      },
+      headers: await headers(),
+    });
+
+    revalidatePath("/admin/users");
+    return { success: true };
+  } catch (error) {
+    return fail(error, "Erro ao banir usuário");
+  }
+}
+
+export async function unbanUserAction(input: unknown): Promise<ActionResult> {
+  try {
+    await requireAdmin();
+    const data = userIdSchema.parse(input);
+
+    await auth.api.unbanUser({
+      body: { userId: data.userId },
+      headers: await headers(),
+    });
+
+    revalidatePath("/admin/users");
+    return { success: true };
+  } catch (error) {
+    return fail(error, "Erro ao desbanir usuário");
+  }
+}
+
+export async function removeUserAction(input: unknown): Promise<ActionResult> {
+  try {
+    await requireAdmin();
+    const data = userIdSchema.parse(input);
+    const currentUserId = await actorUserId();
+
+    if (currentUserId && data.userId === currentUserId) {
+      return { success: false, error: "Você não pode excluir a si mesmo." };
+    }
+
+    await auth.api.removeUser({
+      body: { userId: data.userId },
+      headers: await headers(),
+    });
+
+    revalidatePath("/admin/users");
+    return { success: true };
+  } catch (error) {
+    return fail(error, "Erro ao excluir usuário");
+  }
+}

--- a/app/(protected)/admin/users/components/CreateUserDialog.tsx
+++ b/app/(protected)/admin/users/components/CreateUserDialog.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  MIN_PASSWORD_LENGTH,
+  ROLE_LABELS,
+  USER_ROLES,
+  generatePassword,
+  type UserRole,
+} from "@/lib/core/auth/user-management";
+
+interface CreateUserDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (input: {
+    name: string;
+    email: string;
+    password: string;
+    role: UserRole;
+  }) => Promise<boolean>;
+}
+
+const emptyForm = {
+  name: "",
+  email: "",
+  password: "",
+  role: "user" as UserRole,
+};
+
+export function CreateUserDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+}: CreateUserDialogProps) {
+  const [form, setForm] = useState(emptyForm);
+  const [loading, setLoading] = useState(false);
+
+  const reset = () => setForm(emptyForm);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) reset();
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    try {
+      const created = await onSubmit(form);
+      if (created) reset();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Novo usuário</DialogTitle>
+          <DialogDescription>
+            Crie uma conta com e-mail e senha. O cadastro público continua
+            desabilitado.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="user-name">Nome</Label>
+            <Input
+              id="user-name"
+              value={form.name}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, name: event.target.value }))
+              }
+              placeholder="Nome completo"
+              required
+              minLength={2}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="user-email">E-mail</Label>
+            <Input
+              id="user-email"
+              type="email"
+              value={form.email}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, email: event.target.value }))
+              }
+              placeholder="usuario@exemplo.com"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="user-password">Senha</Label>
+            <div className="flex gap-2">
+              <Input
+                id="user-password"
+                type="text"
+                value={form.password}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    password: event.target.value,
+                  }))
+                }
+                placeholder={`Mínimo ${MIN_PASSWORD_LENGTH} caracteres`}
+                required
+                minLength={MIN_PASSWORD_LENGTH}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  setForm((current) => ({
+                    ...current,
+                    password: generatePassword(),
+                  }))
+                }
+              >
+                Gerar
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="user-role">Papel</Label>
+            <Select
+              value={form.role}
+              onValueChange={(value) =>
+                setForm((current) => ({ ...current, role: value as UserRole }))
+              }
+            >
+              <SelectTrigger id="user-role">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {USER_ROLES.map((role) => (
+                  <SelectItem key={role} value={role}>
+                    {ROLE_LABELS[role]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Criando..." : "Criar usuário"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(protected)/admin/users/components/SetPasswordDialog.tsx
+++ b/app/(protected)/admin/users/components/SetPasswordDialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  MIN_PASSWORD_LENGTH,
+  generatePassword,
+} from "@/lib/core/auth/user-management";
+import type { ManagedUser } from "../actions";
+
+interface SetPasswordDialogProps {
+  user: ManagedUser | null;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (userId: string, password: string) => Promise<boolean>;
+}
+
+export function SetPasswordDialog({
+  user,
+  onOpenChange,
+  onSubmit,
+}: SetPasswordDialogProps) {
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) setPassword("");
+    onOpenChange(open);
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!user) return;
+    setLoading(true);
+    try {
+      const updated = await onSubmit(user.id, password);
+      if (updated) setPassword("");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={Boolean(user)} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Definir senha</DialogTitle>
+          <DialogDescription>
+            Defina uma senha de e-mail para {user?.name || user?.email}. O
+            usuário poderá entrar com e-mail e senha.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="set-password">Nova senha</Label>
+            <div className="flex gap-2">
+              <Input
+                id="set-password"
+                type="text"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder={`Mínimo ${MIN_PASSWORD_LENGTH} caracteres`}
+                required
+                minLength={MIN_PASSWORD_LENGTH}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setPassword(generatePassword())}
+              >
+                Gerar
+              </Button>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={loading || !user}>
+              {loading ? "Salvando..." : "Salvar senha"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(protected)/admin/users/components/UsersManager.tsx
+++ b/app/(protected)/admin/users/components/UsersManager.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { Plus, Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { isAdminRole, type UserRole } from "@/lib/core/auth/user-management";
+import {
+  banUserAction,
+  createUserAction,
+  removeUserAction,
+  setUserPasswordAction,
+  unbanUserAction,
+  updateUserRoleAction,
+  type ManagedUser,
+} from "../actions";
+import { CreateUserDialog } from "./CreateUserDialog";
+import { SetPasswordDialog } from "./SetPasswordDialog";
+import { UsersTable } from "./UsersTable";
+
+interface UsersManagerProps {
+  users: ManagedUser[];
+  currentUserId: string;
+}
+
+export function UsersManager({ users, currentUserId }: UsersManagerProps) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [passwordUser, setPasswordUser] = useState<ManagedUser | null>(null);
+  const [pendingUserId, setPendingUserId] = useState<string | null>(null);
+
+  const stats = useMemo(() => {
+    return {
+      total: users.length,
+      admins: users.filter((user) => isAdminRole(user.role)).length,
+      banned: users.filter((user) => user.banned).length,
+    };
+  }, [users]);
+
+  const handleCreate = async (input: {
+    name: string;
+    email: string;
+    password: string;
+    role: UserRole;
+  }) => {
+    const result = await createUserAction(input);
+    if (!result.success) {
+      toast.error(result.error);
+      return false;
+    }
+    toast.success("Usuário criado com sucesso");
+    setCreateOpen(false);
+    return true;
+  };
+
+  const handleRoleChange = async (userId: string, role: UserRole) => {
+    setPendingUserId(userId);
+    const result = await updateUserRoleAction({ userId, role });
+    setPendingUserId(null);
+    if (!result.success) {
+      toast.error(result.error);
+      return;
+    }
+    toast.success("Papel atualizado");
+  };
+
+  const handleSetPassword = async (userId: string, password: string) => {
+    const result = await setUserPasswordAction({ userId, password });
+    if (!result.success) {
+      toast.error(result.error);
+      return false;
+    }
+    toast.success("Senha definida com sucesso");
+    setPasswordUser(null);
+    return true;
+  };
+
+  const handleBanToggle = async (user: ManagedUser) => {
+    setPendingUserId(user.id);
+    const result = user.banned
+      ? await unbanUserAction({ userId: user.id })
+      : await banUserAction({ userId: user.id });
+    setPendingUserId(null);
+    if (!result.success) {
+      toast.error(result.error);
+      return;
+    }
+    toast.success(user.banned ? "Usuário desbanido" : "Usuário banido");
+  };
+
+  const handleRemove = async (user: ManagedUser) => {
+    setPendingUserId(user.id);
+    const result = await removeUserAction({ userId: user.id });
+    setPendingUserId(null);
+    if (!result.success) {
+      toast.error(result.error);
+      return;
+    }
+    toast.success("Usuário excluído");
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Usuários</h1>
+            <p className="mt-2 text-gray-600">
+              Crie contas com e-mail e senha e gerencie papéis de acesso
+            </p>
+          </div>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4" />
+            Novo usuário
+          </Button>
+        </div>
+
+        <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
+          <div className="rounded-lg bg-white p-6 shadow">
+            <div className="text-2xl font-bold text-gray-900">{stats.total}</div>
+            <div className="text-sm text-gray-600">Total de usuários</div>
+          </div>
+          <div className="rounded-lg bg-white p-6 shadow">
+            <div className="text-2xl font-bold text-blue-600">{stats.admins}</div>
+            <div className="text-sm text-gray-600">Administradores</div>
+          </div>
+          <div className="rounded-lg bg-white p-6 shadow">
+            <div className="text-2xl font-bold text-red-600">{stats.banned}</div>
+            <div className="text-sm text-gray-600">Banidos</div>
+          </div>
+        </div>
+
+        {users.length === 0 ? (
+          <div className="rounded-lg bg-white p-8 text-center shadow-md">
+            <Users className="mx-auto mb-4 h-12 w-12 text-gray-400" />
+            <h3 className="mb-2 text-lg font-medium text-gray-900">
+              Nenhum usuário cadastrado
+            </h3>
+            <p className="text-gray-600">
+              Comece criando o primeiro usuário com e-mail e senha.
+            </p>
+          </div>
+        ) : (
+          <UsersTable
+            users={users}
+            currentUserId={currentUserId}
+            pendingUserId={pendingUserId}
+            onRoleChange={handleRoleChange}
+            onSetPassword={setPasswordUser}
+            onBanToggle={handleBanToggle}
+            onRemove={handleRemove}
+          />
+        )}
+      </div>
+
+      <CreateUserDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onSubmit={handleCreate}
+      />
+
+      <SetPasswordDialog
+        user={passwordUser}
+        onOpenChange={(open) => {
+          if (!open) setPasswordUser(null);
+        }}
+        onSubmit={handleSetPassword}
+      />
+    </div>
+  );
+}

--- a/app/(protected)/admin/users/components/UsersTable.tsx
+++ b/app/(protected)/admin/users/components/UsersTable.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { MoreHorizontal } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  ROLE_LABELS,
+  USER_ROLES,
+  parseUserRole,
+  type UserRole,
+} from "@/lib/core/auth/user-management";
+import type { ManagedUser } from "../actions";
+
+interface UsersTableProps {
+  users: ManagedUser[];
+  currentUserId: string;
+  pendingUserId: string | null;
+  onRoleChange: (userId: string, role: UserRole) => Promise<void>;
+  onSetPassword: (user: ManagedUser) => void;
+  onBanToggle: (user: ManagedUser) => Promise<void>;
+  onRemove: (user: ManagedUser) => Promise<void>;
+}
+
+function providerLabel(providers: string[]): string {
+  const labels = providers.map((provider) => {
+    if (provider === "credential") return "E-mail";
+    if (provider === "google") return "Google";
+    return provider;
+  });
+  return labels.length > 0 ? labels.join(", ") : "—";
+}
+
+export function UsersTable({
+  users,
+  currentUserId,
+  pendingUserId,
+  onRoleChange,
+  onSetPassword,
+  onBanToggle,
+  onRemove,
+}: UsersTableProps) {
+  return (
+    <div className="overflow-hidden rounded-lg bg-white shadow-md">
+      <div className="border-b border-gray-200 px-6 py-4">
+        <h2 className="text-lg font-medium text-gray-900">
+          Usuários cadastrados ({users.length})
+        </h2>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Nome
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                E-mail
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Acesso
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Papel
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Status
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Ações
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {users.map((user) => {
+              const isSelf = user.id === currentUserId;
+              const isPending = pendingUserId === user.id;
+              const role = parseUserRole(user.role);
+
+              return (
+                <tr key={user.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="text-sm font-medium text-gray-900">
+                      {user.name || "—"}
+                      {isSelf && (
+                        <span className="ml-2 text-xs text-gray-500">(você)</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="text-sm text-gray-900">{user.email}</div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="text-sm text-gray-900">
+                      {providerLabel(user.providers)}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <Select
+                      value={role}
+                      disabled={isSelf || isPending}
+                      onValueChange={(value) =>
+                        onRoleChange(user.id, value as UserRole)
+                      }
+                    >
+                      <SelectTrigger className="h-8 w-36">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {USER_ROLES.map((value) => (
+                          <SelectItem key={value} value={value}>
+                            {ROLE_LABELS[value]}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <Badge variant={user.banned ? "destructive" : "secondary"}>
+                      {user.banned ? "Banido" : "Ativo"}
+                    </Badge>
+                  </td>
+                  <td className="px-6 py-4 text-right whitespace-nowrap">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          disabled={isPending}
+                          aria-label={`Ações de ${user.name || user.email}`}
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => onSetPassword(user)}>
+                          Definir senha
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          disabled={isSelf}
+                          onClick={() => onBanToggle(user)}
+                        >
+                          {user.banned ? "Desbanir" : "Banir"}
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          disabled={isSelf}
+                          className="text-red-600"
+                          onClick={() => {
+                            const confirmed = window.confirm(
+                              `Excluir o usuário ${user.email}? Esta ação não pode ser desfeita.`
+                            );
+                            if (confirmed) {
+                              void onRemove(user);
+                            }
+                          }}
+                        >
+                          Excluir
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/admin/users/page.tsx
+++ b/app/(protected)/admin/users/page.tsx
@@ -1,69 +1,18 @@
-import { prisma } from "@/lib/core/database/client";
-import { auth } from "@/lib/core/auth/auth";
-import { requireAdmin } from "@/lib/core/auth/permission-helpers";
-import { headers } from "next/headers";
-
-type Role = "admin" | "user" | "superuser";
+import { requireAdminOrRedirect } from "@/lib/core/auth/permission-helpers";
+import { getCurrentUser } from "@/lib/core/auth/auth-utils";
+import { listManagedUsers } from "./actions";
+import { UsersManager } from "./components/UsersManager";
 
 export const dynamic = "force-dynamic";
 
-// Page view permissions removed
-
-async function getData() {
-  const users = await prisma.user.findMany({
-    orderBy: { email: "asc" },
-    select: { id: true, email: true, name: true, role: true },
-  });
-  return users;
-}
-
-async function updateRoleAction(formData: FormData) {
-  "use server";
-  await requireAdmin();
-  const userId = String(formData.get("userId") || "").trim();
-  const role = (String(formData.get("role") || "user").toLowerCase() as Role);
-  if (!userId) return;
-  await auth.api.setRole({ body: { userId, role }, headers: await headers() });
-}
-
 export default async function UsersAdminPage() {
-  const users = await getData();
+  await requireAdminOrRedirect();
+  const [users, currentUser] = await Promise.all([
+    listManagedUsers(),
+    getCurrentUser(),
+  ]);
 
   return (
-    <div className="p-6 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">Controle de Usuários</h1>
-      <p className="text-sm text-gray-600 mb-6">
-        Apenas administradores podem acessar esta página. Gerencie as permissões via Better Auth.
-      </p>
-
-      <table className="w-full text-sm border rounded overflow-hidden">
-        <thead className="bg-gray-100">
-          <tr>
-            <th className="text-left p-2 border-b">Nome</th>
-            <th className="text-left p-2 border-b">E-mail</th>
-            <th className="text-left p-2 border-b">Papel</th>
-          </tr>
-        </thead>
-        <tbody>
-          {users.map((u) => (
-            <tr key={u.id} className="border-b">
-              <td className="p-2">{u.name ?? "—"}</td>
-              <td className="p-2">{u.email}</td>
-              <td className="p-2">
-                <form action={updateRoleAction} className="inline-flex gap-2 items-center">
-                  <input type="hidden" name="userId" value={u.id} />
-                  <select name="role" defaultValue={(u.role as Role) ?? "user"} className="border rounded px-2 py-1">
-                    <option value="user">Usuário</option>
-                    <option value="admin">Admin</option>
-                    <option value="superuser">Superuser</option>
-                  </select>
-                  <button type="submit" className="text-blue-600">Salvar</button>
-                </form>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <UsersManager users={users} currentUserId={currentUser?.id ?? ""} />
   );
 }

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -137,7 +137,7 @@ export default async function SettingsPage() {
                 <div>
                   <p className="font-medium">Provedor de Autenticação</p>
                   <p className="text-sm text-muted-foreground">
-                    Você está autenticado via Google OAuth
+                    Login disponível via e-mail e senha ou Google OAuth
                   </p>
                 </div>
                 <div className="flex items-center space-x-2">

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -2,30 +2,48 @@
 
 import { useAuth } from "@/hooks/use-auth";
 import { useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useState, type FormEvent } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function SignInPage() {
-  const { isLoading, signInWithGoogle } = useAuth();
+  const { isLoading, signInWithGoogle, signInWithEmail } = useAuth();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
-  // Relaxed: do not gate by role or redirect if already authenticated
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
   const queryError =
     searchParams.get("error") === "unauthorized"
       ? "Acesso negado. Apenas usuários autorizados podem acessar o sistema."
       : null;
   const errorMessage = error ?? queryError;
 
-  // Do not auto-redirect when already authenticated; let the user stay here
+  const handleEmailSignIn = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      setError(null);
+      setSubmitting(true);
+      await signInWithEmail(email, password);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Erro ao fazer login. Por favor, tente novamente.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
-  const handleSignIn = async () => {
+  const handleGoogleSignIn = async () => {
     try {
       setError(null);
       await signInWithGoogle();
     } catch (err: unknown) {
-      // Handle authentication errors
       if (err instanceof Error && err.message.includes("Acesso negado")) {
         setError("Acesso negado. Apenas usuários autorizados podem acessar o sistema.");
       } else {
@@ -33,8 +51,6 @@ export default function SignInPage() {
       }
     }
   };
-
-  // Relaxed: still show sign-in page even if authenticated
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800">
@@ -51,10 +67,57 @@ export default function SignInPage() {
               <AlertDescription>{errorMessage}</AlertDescription>
             </Alert>
           )}
+
+          <form onSubmit={handleEmailSignIn} className="space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="signin-email">E-mail</Label>
+              <Input
+                id="signin-email"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="seu@email.com"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="signin-password">Senha</Label>
+              <Input
+                id="signin-password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder="Sua senha"
+                required
+                minLength={8}
+              />
+            </div>
+            <Button
+              type="submit"
+              disabled={isLoading || submitting}
+              className="w-full"
+              size="lg"
+            >
+              {submitting ? "Entrando..." : "Entrar com e-mail"}
+            </Button>
+          </form>
+
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-background px-2 text-muted-foreground">
+                ou continue com
+              </span>
+            </div>
+          </div>
           
           <Button
-            onClick={handleSignIn}
-            disabled={isLoading}
+            onClick={handleGoogleSignIn}
+            disabled={isLoading || submitting}
             className="w-full"
             size="lg"
             variant="outline"
@@ -77,26 +140,8 @@ export default function SignInPage() {
             {isLoading ? "Conectando..." : "Entrar com Google"}
           </Button>
 
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">
-                Acesso seguro
-              </span>
-            </div>
-          </div>
-
           <p className="text-center text-sm text-muted-foreground">
-            Ao fazer login, você concorda com nossos{" "}
-            <a href="#" className="underline underline-offset-4 hover:text-primary">
-              Termos de Uso
-            </a>{" "}
-            e{" "}
-            <a href="#" className="underline underline-offset-4 hover:text-primary">
-              Política de Privacidade
-            </a>
+            O cadastro é feito apenas por um administrador.
           </p>
         </CardContent>
       </Card>

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -24,6 +24,7 @@ import {
   FileText as FileTextIcon,
   BookOpen,
   Receipt,
+  Users,
 } from 'lucide-react';
 
 const navigation = [
@@ -66,6 +67,10 @@ const helpOptions = [
   { name: 'Manual', href: '/manual', icon: BookOpen },
 ];
 
+const adminOptions = [
+  { name: 'Usuários', href: '/admin/users', icon: Users },
+];
+
 // ...existing code...
 
 export default function Navbar() {
@@ -75,6 +80,7 @@ export default function Navbar() {
   const session = useSession();
   const role = session.data?.user?.role as string | undefined;
   const canSeeReports = role === 'admin' || role === 'superuser';
+  const canManageUsers = canSeeReports;
 
   return (
     <nav className="bg-white shadow-sm border-b">
@@ -232,6 +238,35 @@ export default function Navbar() {
                         </Link>
                       );
                     })}
+
+                    {canManageUsers && (
+                      <>
+                        <Separator className="my-2" />
+                        <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                          Administração
+                        </div>
+                        {adminOptions.map((item) => {
+                          const Icon = item.icon;
+                          const isActive = pathname === item.href;
+
+                          return (
+                            <Link
+                              key={item.name}
+                              href={item.href}
+                              onClick={() => setIsDropdownOpen(false)}
+                              className={`flex items-center px-4 py-2 text-sm transition-colors ${
+                                isActive
+                                  ? 'text-blue-600 bg-blue-50'
+                                  : 'text-gray-700 hover:bg-gray-100'
+                              }`}
+                            >
+                              <Icon className="w-4 h-4 mr-2" />
+                              {item.name}
+                            </Link>
+                          );
+                        })}
+                      </>
+                    )}
 
                     <Separator className="my-2" />
 
@@ -472,6 +507,40 @@ export default function Navbar() {
                       </Link>
                     );
                   })}
+
+                  {canManageUsers && (
+                    <>
+                      <div className="px-8">
+                        <Separator className="my-2" />
+                      </div>
+                      <div className="pl-8 pr-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                        Administração
+                      </div>
+                      {adminOptions.map((item) => {
+                        const Icon = item.icon;
+                        const isActive = pathname === item.href;
+
+                        return (
+                          <Link
+                            key={item.name}
+                            href={item.href}
+                            onClick={() => {
+                              setIsDropdownOpen(false);
+                              setIsMobileMenuOpen(false);
+                            }}
+                            className={`flex items-center pl-8 pr-4 py-2 text-sm font-medium transition-colors ${
+                              isActive
+                                ? 'text-blue-600 bg-blue-50'
+                                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+                            }`}
+                          >
+                            <Icon className="w-4 h-4 mr-2" />
+                            {item.name}
+                          </Link>
+                        );
+                      })}
+                    </>
+                  )}
 
                   <div className="px-8">
                     <Separator className="my-2" />

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -4,7 +4,8 @@ import { useState, useRef, useEffect } from "react";
 import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { User, LogOut, Settings } from "lucide-react";
+import { User, LogOut, Settings, Users } from "lucide-react";
+import { isAdminRole } from "@/lib/core/auth/user-management";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -98,6 +99,17 @@ export default function UserMenu() {
               <Settings className="mr-3 h-4 w-4" />
               Configurações
             </Link>
+
+            {isAdminRole(user?.role) && (
+              <Link
+                href="/admin/users"
+                onClick={() => setIsOpen(false)}
+                className="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+              >
+                <Users className="mr-3 h-4 w-4" />
+                Usuários
+              </Link>
+            )}
 
             <Separator />
 

--- a/app/components/WelcomeHero.tsx
+++ b/app/components/WelcomeHero.tsx
@@ -7,7 +7,7 @@ import { ArrowRight, Shield, TrendingUp, FileText } from "lucide-react";
 import Link from "next/link";
 
 export default function WelcomeHero() {
-  const { user, isAuthenticated, isLoading, signInWithGoogle } = useAuth();
+  const { user, isAuthenticated } = useAuth();
   const session = useSession();
   const role = session.data?.user?.role as string | undefined;
   const canSeeReports = role === 'admin' || role === 'superuser';
@@ -22,10 +22,12 @@ export default function WelcomeHero() {
           <p className="text-xl text-gray-600 mb-8">
             Gerencie suas finanças com segurança e eficiência
           </p>
-          <Button onClick={signInWithGoogle} size="lg" className="font-semibold" disabled={isLoading}>
-            <Shield className="mr-2 h-5 w-5" />
-            {isLoading ? "Conectando..." : "Fazer Login com Google"}
-            <ArrowRight className="ml-2 h-5 w-5" />
+          <Button asChild size="lg" className="font-semibold">
+            <Link href="/auth/signin">
+              <Shield className="mr-2 h-5 w-5" />
+              Fazer login
+              <ArrowRight className="ml-2 h-5 w-5" />
+            </Link>
           </Button>
           
           <div className="mt-12 grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
@@ -42,7 +44,7 @@ export default function WelcomeHero() {
             <div className="text-center">
               <Shield className="h-12 w-12 text-blue-600 mx-auto mb-4" />
               <h3 className="font-semibold text-lg mb-2">Segurança Total</h3>
-              <p className="text-gray-600">Autenticação segura com Google OAuth</p>
+              <p className="text-gray-600">Autenticação segura com e-mail ou Google</p>
             </div>
           </div>
         </div>

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -9,11 +9,10 @@ export function useAuth() {
   const session = useSession();
   const searchParams = useSearchParams();
 
+  const redirectTo = searchParams.get("redirect") || "/";
+
   const signInWithGoogle = async () => {
     try {
-      // Get the redirect parameter from URL, fallback to "/"
-      const redirectTo = searchParams.get("redirect") || "/";
-      
       await signIn.social({
         provider: "google",
         callbackURL: redirectTo,
@@ -22,6 +21,26 @@ export function useAuth() {
       console.error("Sign in error:", error);
       toast.error("Erro ao fazer login. Por favor, tente novamente.");
     }
+  };
+
+  const signInWithEmail = async (email: string, password: string) => {
+    const { error } = await signIn.email({
+      email,
+      password,
+      callbackURL: redirectTo,
+    });
+
+    if (error) {
+      const message =
+        error.message?.toLowerCase().includes("invalid") ||
+        error.code === "INVALID_EMAIL_OR_PASSWORD"
+          ? "E-mail ou senha inválidos."
+          : "Erro ao fazer login. Por favor, tente novamente.";
+      toast.error(message);
+      throw new Error(message);
+    }
+
+    router.push(redirectTo);
   };
 
   const handleSignOut = async () => {
@@ -41,6 +60,7 @@ export function useAuth() {
     isLoading: session.isPending,
     isAuthenticated: !!session.data,
     signInWithGoogle,
+    signInWithEmail,
     signOut: handleSignOut,
   };
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -17,9 +17,11 @@ export const auth = betterAuth({
     },
   },
 
-  // Email & Password disabled (using only Google OAuth)
   emailAndPassword: {
-    enabled: false,
+    enabled: true,
+    disableSignUp: true,
+    minPasswordLength: 8,
+    autoSignIn: false,
   },
 
   // Session configuration

--- a/lib/core/auth/auth-utils.ts
+++ b/lib/core/auth/auth-utils.ts
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { Session, User } from "./auth";
 import { ADMIN_PERMISSION } from "./permissions";
+import { isPermissionGranted } from "./user-management";
 
 /**
  * Get the current session from server components
@@ -53,14 +54,14 @@ export async function isAdmin(): Promise<boolean> {
   const session = await getServerSession();
   if (!session) return false;
   try {
-    const has = await auth.api.userHasPermission({
+    const result = await auth.api.userHasPermission({
       body: {
         userId: session.session.userId,
         permissions: ADMIN_PERMISSION,
       },
       headers: await headers(),
     });
-    return !!has;
+    return isPermissionGranted(result);
   } catch {
     return false;
   }

--- a/lib/core/auth/auth.ts
+++ b/lib/core/auth/auth.ts
@@ -20,9 +20,12 @@ export const auth = betterAuth({
     },
   },
 
-  // Email & Password disabled (using only Google OAuth)
+  // Email & password for admin-created users. Public sign-up stays closed.
   emailAndPassword: {
-    enabled: false,
+    enabled: true,
+    disableSignUp: true,
+    minPasswordLength: 8,
+    autoSignIn: false,
   },
 
   // Session configuration

--- a/lib/core/auth/index.ts
+++ b/lib/core/auth/index.ts
@@ -29,4 +29,14 @@ export {
   getCurrentUser,
   requireAuth,
   isAuthenticated,
+  isAdmin,
 } from './auth-utils';
+
+export {
+  USER_ROLES,
+  ROLE_LABELS,
+  isAdminRole,
+  parseUserRole,
+  MIN_PASSWORD_LENGTH,
+} from './user-management';
+export type { UserRole } from './user-management';

--- a/lib/core/auth/permission-helpers.ts
+++ b/lib/core/auth/permission-helpers.ts
@@ -1,6 +1,8 @@
 import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 import { auth } from "./auth";
 import { ADMIN_PERMISSION, type statement } from "./permissions";
+import { isPermissionGranted } from "./user-management";
 
 // Map of resource -> allowed actions, constrained by our access control statement
 export type Permissions = {
@@ -16,18 +18,38 @@ export async function requirePermissions(permissions: Permissions): Promise<void
   const session = await auth.api.getSession({ headers: hdrs });
   if (!session) throw new Error("Unauthorized");
 
-  const ok = await auth.api.userHasPermission({
+  const result = await auth.api.userHasPermission({
     headers: hdrs,
     body: {
       userId: session.session.userId,
       permissions,
     },
   });
-  if (!ok) throw new Error("Forbidden");
+  if (!isPermissionGranted(result)) throw new Error("Forbidden");
 }
 
 /** Convenience helper for admin-only server actions */
 export async function requireAdmin(): Promise<void> {
   await requirePermissions(ADMIN_PERMISSION);
+}
+
+/** Redirect unauthenticated or non-admin visitors away from admin pages */
+export async function requireAdminOrRedirect(redirectTo = "/admin/users"): Promise<void> {
+  const hdrs = await headers();
+  const session = await auth.api.getSession({ headers: hdrs });
+  if (!session) {
+    redirect(`/auth/signin?redirect=${encodeURIComponent(redirectTo)}`);
+  }
+
+  const result = await auth.api.userHasPermission({
+    headers: hdrs,
+    body: {
+      userId: session.session.userId,
+      permissions: ADMIN_PERMISSION,
+    },
+  });
+  if (!isPermissionGranted(result)) {
+    redirect("/");
+  }
 }
 

--- a/lib/core/auth/user-management.ts
+++ b/lib/core/auth/user-management.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+
+export const USER_ROLES = ["user", "admin", "superuser"] as const;
+export type UserRole = (typeof USER_ROLES)[number];
+
+export const MIN_PASSWORD_LENGTH = 8;
+
+export const ROLE_LABELS: Record<UserRole, string> = {
+  user: "Usuário",
+  admin: "Admin",
+  superuser: "Superuser",
+};
+
+export function isAdminRole(role: string | null | undefined): boolean {
+  return role === "admin" || role === "superuser";
+}
+
+export function generatePassword(length = 12): string {
+  const chars = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => chars[byte % chars.length]).join("");
+}
+
+export function parseUserRole(value: string | null | undefined): UserRole {
+  if (value === "admin" || value === "superuser" || value === "user") {
+    return value;
+  }
+  return "user";
+}
+
+export const createUserSchema = z.object({
+  name: z.string().trim().min(2, "Informe o nome (mínimo 2 caracteres)"),
+  email: z
+    .string()
+    .trim()
+    .email("E-mail inválido")
+    .transform((value) => value.toLowerCase()),
+  password: z
+    .string()
+    .min(
+      MIN_PASSWORD_LENGTH,
+      `A senha deve ter pelo menos ${MIN_PASSWORD_LENGTH} caracteres`
+    ),
+  role: z.enum(USER_ROLES),
+});
+
+export const setPasswordSchema = z.object({
+  userId: z.string().min(1, "Usuário inválido"),
+  password: z
+    .string()
+    .min(
+      MIN_PASSWORD_LENGTH,
+      `A senha deve ter pelo menos ${MIN_PASSWORD_LENGTH} caracteres`
+    ),
+});
+
+export const setRoleSchema = z.object({
+  userId: z.string().min(1, "Usuário inválido"),
+  role: z.enum(USER_ROLES),
+});
+
+export const userIdSchema = z.object({
+  userId: z.string().min(1, "Usuário inválido"),
+});
+
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  USER_ALREADY_EXISTS: "Já existe um usuário com este e-mail",
+  USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL: "Já existe um usuário com este e-mail",
+  FAILED_TO_CREATE_USER: "Não foi possível criar o usuário",
+  YOU_CANNOT_BAN_YOURSELF: "Você não pode banir a si mesmo",
+  YOU_ARE_NOT_ALLOWED_TO_CREATE_USERS:
+    "Sem permissão para criar usuários",
+  YOU_ARE_NOT_ALLOWED_TO_CHANGE_USERS_ROLE:
+    "Sem permissão para alterar papéis",
+  YOU_ARE_NOT_ALLOWED_TO_BAN_USERS: "Sem permissão para banir usuários",
+  YOU_ARE_NOT_ALLOWED_TO_DELETE_USERS: "Sem permissão para excluir usuários",
+  YOU_ARE_NOT_ALLOWED_TO_SET_USER_PASSWORD:
+    "Sem permissão para alterar senhas",
+};
+
+function readErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const record = error as {
+    code?: string;
+    body?: { code?: string };
+  };
+  return record.body?.code ?? record.code;
+}
+
+function readErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error && error.message) return error.message;
+  if (!error || typeof error !== "object") return undefined;
+  const record = error as {
+    message?: string;
+    body?: { message?: string };
+  };
+  return record.body?.message ?? record.message;
+}
+
+export function mapAuthError(error: unknown, fallback: string): string {
+  const code = readErrorCode(error);
+  if (code && AUTH_ERROR_MESSAGES[code]) {
+    return AUTH_ERROR_MESSAGES[code];
+  }
+
+  const message = readErrorMessage(error);
+  if (!message) return fallback;
+
+  const normalized = message.toLowerCase();
+  if (normalized.includes("already exists")) {
+    return AUTH_ERROR_MESSAGES.USER_ALREADY_EXISTS;
+  }
+  if (normalized.includes("password") && normalized.includes("least")) {
+    return `A senha deve ter pelo menos ${MIN_PASSWORD_LENGTH} caracteres`;
+  }
+
+  return fallback;
+}
+
+export function firstZodError(error: z.ZodError): string {
+  return error.issues[0]?.message ?? "Dados inválidos";
+}
+
+export function isPermissionGranted(
+  result: { success?: boolean } | boolean | null | undefined
+): boolean {
+  if (typeof result === "boolean") return result;
+  return result?.success === true;
+}

--- a/tests/unit/user-management.test.ts
+++ b/tests/unit/user-management.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createUserSchema,
+  generatePassword,
+  isAdminRole,
+  isPermissionGranted,
+  mapAuthError,
+  MIN_PASSWORD_LENGTH,
+  parseUserRole,
+  setPasswordSchema,
+  setRoleSchema,
+} from '@/lib/core/auth/user-management';
+
+describe('user management helpers', () => {
+  describe('isAdminRole', () => {
+    it('accepts admin and superuser', () => {
+      expect(isAdminRole('admin')).toBe(true);
+      expect(isAdminRole('superuser')).toBe(true);
+    });
+
+    it('rejects regular users and empty values', () => {
+      expect(isAdminRole('user')).toBe(false);
+      expect(isAdminRole(null)).toBe(false);
+      expect(isAdminRole(undefined)).toBe(false);
+    });
+  });
+
+  describe('parseUserRole', () => {
+    it('returns known roles and defaults to user', () => {
+      expect(parseUserRole('admin')).toBe('admin');
+      expect(parseUserRole('superuser')).toBe('superuser');
+      expect(parseUserRole('user')).toBe('user');
+      expect(parseUserRole('unknown')).toBe('user');
+      expect(parseUserRole(null)).toBe('user');
+    });
+  });
+
+  describe('createUserSchema', () => {
+    it('accepts a valid payload and normalizes email', () => {
+      const result = createUserSchema.parse({
+        name: 'Maria Silva',
+        email: '  Maria@RATC.com  ',
+        password: 'senha-segura',
+        role: 'user',
+      });
+
+      expect(result.email).toBe('maria@ratc.com');
+      expect(result.role).toBe('user');
+    });
+
+    it('rejects short name, invalid email and short password', () => {
+      const result = createUserSchema.safeParse({
+        name: 'A',
+        email: 'nao-e-email',
+        password: '123',
+        role: 'user',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('setPasswordSchema', () => {
+    it('requires the minimum password length', () => {
+      const invalid = setPasswordSchema.safeParse({
+        userId: 'user-1',
+        password: '1234567',
+      });
+      const valid = setPasswordSchema.safeParse({
+        userId: 'user-1',
+        password: '12345678',
+      });
+
+      expect(invalid.success).toBe(false);
+      expect(valid.success).toBe(true);
+      expect(MIN_PASSWORD_LENGTH).toBe(8);
+    });
+  });
+
+  describe('setRoleSchema', () => {
+    it('rejects unknown roles', () => {
+      const result = setRoleSchema.safeParse({
+        userId: 'user-1',
+        role: 'owner',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('mapAuthError', () => {
+    it('maps known Better Auth codes', () => {
+      expect(
+        mapAuthError({ body: { code: 'USER_ALREADY_EXISTS' } }, 'fallback')
+      ).toBe('Já existe um usuário com este e-mail');
+    });
+
+    it('maps already-exists messages without a code', () => {
+      expect(mapAuthError(new Error('User already exists'), 'fallback')).toBe(
+        'Já existe um usuário com este e-mail'
+      );
+    });
+
+    it('returns the fallback for unknown errors', () => {
+      expect(mapAuthError({}, 'Erro ao criar usuário')).toBe(
+        'Erro ao criar usuário'
+      );
+    });
+  });
+
+  describe('isPermissionGranted', () => {
+    it('supports boolean and object responses', () => {
+      expect(isPermissionGranted(true)).toBe(true);
+      expect(isPermissionGranted(false)).toBe(false);
+      expect(isPermissionGranted({ success: true })).toBe(true);
+      expect(isPermissionGranted({ success: false })).toBe(false);
+      expect(isPermissionGranted(null)).toBe(false);
+    });
+  });
+
+  describe('generatePassword', () => {
+    it('generates a password with the requested length', () => {
+      const password = generatePassword(12);
+      expect(password).toHaveLength(12);
+      expect(password).toMatch(/^[a-zA-Z0-9]+$/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Admins passam a criar usuários com e-mail, senha e papel em `/admin/users`.
- Login aceita e-mail/senha além do Google; o cadastro público continua fechado.
- Papel, senha, banimento e exclusão ficam na mesma tela, sem o admin alterar a própria conta.

## Test plan
- [ ] Entrar como admin e abrir **Mais → Administração → Usuários**
- [ ] Criar um usuário com e-mail e senha
- [ ] Sair e entrar com esse e-mail/senha em `/auth/signin`
- [ ] Confirmar que o login com Google continua funcionando
- [ ] Alterar papel, definir senha, banir/desbanir e excluir outro usuário
- [ ] Confirmar que um usuário comum não acessa `/admin/users`


Made with [Cursor](https://cursor.com)